### PR TITLE
Re-enabled barcode validation

### DIFF
--- a/custom_validator.py
+++ b/custom_validator.py
@@ -51,10 +51,9 @@ class CustomValidator(Validator):
       if col_alpha_range and self.document.get('col_is_alpha') and value > 26:
         self._error(field, 'Too many columns for alphabetical enumeration')
 
-    def validate_immutable_barcode(self, data, existing):
-      field = u'barcode'
+    def validate_immutable_field(self, field, data, existing):
       if existing and data and field in data and data[field]!=existing[field]:
-        self._error(field, 'The barcode field cannot be updated.')
+        self._error(field, 'The %s field cannot be updated.'%field)
         return False
       return True
 
@@ -65,8 +64,8 @@ class CustomValidator(Validator):
     def validate_update(self, data, uuid, context):
       self.is_new = False
       validated = super(CustomValidator, self).validate_update(data, uuid, context)
-      if not self.validate_immutable_barcode(data, context):
-        validated = False
-      # TODO - block updating other fields, i.e. num_of_rows/cols, row/col_is_alpha
+      for field in 'num_of_rows num_of_cols row_is_alpha col_is_alpha barcode'.split():
+        if not self.validate_immutable_field(field, data, context):
+          validated = False
       return validated
  

--- a/custom_validator.py
+++ b/custom_validator.py
@@ -2,6 +2,7 @@ from eve.io.mongo import Validator
 from uuid import UUID
 from collections import Counter
 from addresser import Addresser
+import pdb
 
 class CustomValidator(Validator):
     """
@@ -11,8 +12,7 @@ class CustomValidator(Validator):
         try:
             UUID(value)
         except ValueError:
-            self._error(field, "value %r cannot be converted to a UUID" %
-                        value)
+            self._error(field, "value %r cannot be converted to a UUID" % value)
 
     def make_addresser(self):
       doc = self.document
@@ -40,7 +40,7 @@ class CustomValidator(Validator):
     def _validate_non_aker_barcode(self, non_aker_barcode, field, value):
       if not non_aker_barcode:
         return
-      if value.upper().startswith('AKER-'):
+      if self.is_new and value.upper().startswith('AKER-'):
         self._error(field, 'AKER barcode not permitted: %s'%value)
 
     def _validate_row_alpha_range(self, row_alpha_range, field, value):
@@ -51,3 +51,22 @@ class CustomValidator(Validator):
       if col_alpha_range and self.document.get('col_is_alpha') and value > 26:
         self._error(field, 'Too many columns for alphabetical enumeration')
 
+    def validate_immutable_barcode(self, data, existing):
+      field = u'barcode'
+      if existing and data and field in data and data[field]!=existing[field]:
+        self._error(field, 'The barcode field cannot be updated.')
+        return False
+      return True
+
+    def validate(self, *args, **kwargs):
+      self.is_new = True
+      return super(CustomValidator, self).validate(*args, **kwargs)
+
+    def validate_update(self, data, uuid, context):
+      self.is_new = False
+      validated = super(CustomValidator, self).validate_update(data, uuid, context)
+      if not self.validate_immutable_barcode(data, context):
+        validated = False
+      # TODO - block updating other fields, i.e. num_of_rows/cols, row/col_is_alpha
+      return validated
+ 

--- a/schema.py
+++ b/schema.py
@@ -111,7 +111,7 @@ container_schema = {
     'type': 'string',
     'unique': True,
     'minlength': 6,
-    'non_aker_barcode': False,
+    'non_aker_barcode': True,
   },
   'slots': {
     'type': 'list',

--- a/tests/containers_tests.py
+++ b/tests/containers_tests.py
@@ -556,15 +556,17 @@ class TestContainers(ServiceTestBase):
     _, status = self.patch('/containers/%s'%plateid, data=update)
     self.assert200(status)
 
-  def test_update_plate_with_different_barcode(self):
+  def test_update_immutable_fields(self):
     data = valid_container_params()
     response, status = self.post('/containers', data=data)
     self.assert201(status)
     plateid = response['_id']
-    update = { 'barcode': 'COLORADO' }
+    update = { 'barcode': 'COLORADO', 'num_of_rows':100, 'col_is_alpha':True }
     response, status = self.patch('/containers/%s'%plateid, data=update)
     self.assertValidationErrorStatus(status)
     self.assertValidationError(response, { 'barcode': 'The barcode field cannot be updated'})
+    self.assertValidationError(response, { 'num_of_rows': 'The num_of_rows field cannot be updated'})
+    self.assertValidationError(response, { 'col_is_alpha': 'The col_is_alpha field cannot be updated'})
 
   def test_update_plate_with_same_barcode(self):
     data = valid_container_params()
@@ -590,4 +592,3 @@ def valid_container_params(changes=None):
   if changes:
     d.update(changes)
   return d
-

--- a/tests/materials_tests.py
+++ b/tests/materials_tests.py
@@ -93,3 +93,4 @@ class TestMaterials(ServiceTestBase):
 
     r, status = self.get('materials', '', r['_id'])
     self.assertEqual(r['meta']['allows'], 'unknown')
+    


### PR DESCRIPTION
Validate new barcodes when creating new labware.
Don't support updating barcode in existing labware.
Allow update to contain a barcode matching the current barcode.