### PR TITLE
made paging work for search-with-post

### DIFF
--- a/run.py
+++ b/run.py
@@ -249,11 +249,10 @@ def create_app(settings):
         meta = { 'max_results': limit, 'total': total, 'page': page }
 
         links = {}
-        if page < pages:
-            links['next'] = { 'page': (page+1) }
         if page > 1:
             links['prev'] = { 'page': (page-1) }
         if page < pages:
+            links['next'] = { 'page': (page+1) }
             links['last'] = { 'page': pages }
 
         msg = { '_items': items, '_meta': meta, '_links': links }

--- a/run.py
+++ b/run.py
@@ -248,10 +248,13 @@ def create_app(settings):
 
         meta = { 'max_results': limit, 'total': total, 'page': page }
 
-        links = {
-            'next': { 'page': (page+1) if page < pages else None },
-            'prev': { 'page': (page-1) if page > 1 else None },
-        }
+        links = {}
+        if page < pages:
+            links['next'] = { 'page': (page+1) }
+        if page > 1:
+            links['prev'] = { 'page': (page-1) }
+        if page < pages:
+            links['last'] = { 'page': pages }
 
         msg = { '_items': items, '_meta': meta, '_links': links }
 


### PR DESCRIPTION
Read 'page' and 'limit' arguments from request.
Added _meta and _links to response.
_links['next'] and ['prev'] just contain the index of the next and previous pages.
They can't contain links, because the page is specified in post data, not in the url.