### PR TITLE
A90 - Add new fields and attributes to material schema

### DIFF
--- a/custom_validator.py
+++ b/custom_validator.py
@@ -80,6 +80,9 @@ class CustomValidator(Validator):
     def _validate_field_name_regex(self, friendly_name, field, value):
         pass
 
+    def _validate_show_on_form(self, show_on_form, field, value):
+        pass
+
     def validate_immutable_field(self, field, data, existing):
         if (existing and data and field in data and field in existing
                 and data[field] != existing[field]):

--- a/run.py
+++ b/run.py
@@ -204,8 +204,9 @@ def create_app(settings):
         required = cerberus_to_json_list(schema, 'required')
         searchable = cerberus_to_json_list(schema, 'searchable')
         amend_required_order(required)
+        show_on_form = cerberus_to_json_list(schema, 'show_on_form')
 
-        return {'type': 'object', 'properties': schema, 'required': required, 'searchable': searchable}
+        return {'type': 'object', 'properties': schema, 'required': required, 'searchable': searchable, 'show_on_form': show_on_form}
 
     @app.route('/containers/json_schema', methods=['GET'])
     def containers_json_schema(**lookup):

--- a/schema.py
+++ b/schema.py
@@ -43,7 +43,7 @@ material_schema = {
     'searchable': True,
     'required': True,
     'friendly_name': 'Supplier name',
-    'field_name_regex': '^supplier[-_\s]*(name)?$'
+    'field_name_regex': '(?i)^supplier[-_\s]*(name)?$'
   },
 'is_tumour': {
   'type': 'string',
@@ -52,7 +52,7 @@ material_schema = {
   'allowed': ['tumour', 'normal'],
   'required': True,
   'friendly_name': 'Tumour?',
-  'field_name_regex': '^(tumour|tumor)$'
+  'field_name_regex': '(?i)^(tumour|tumor)$'
 },
   'tissue_type': {
     'type': 'string',
@@ -61,7 +61,7 @@ material_schema = {
     'allowed': ['DNA/RNA', 'Blood', 'Saliva', 'Tissue', 'Cells', 'Lysed Cells'],
     'required': True,
     'friendly_name': 'Tissue Type',
-    'field_name_regex': '^tissue[-_\s]type$'
+    'field_name_regex': '(?i)^tissue[-_\s]type$'
   },
   'donor_id': {
     'type': 'string',
@@ -69,7 +69,7 @@ material_schema = {
     'searchable': True,
     'required': True,
     'friendly_name': 'Donor ID',
-    'field_name_regex': '^donor[-_\s]*(id)?$'
+    'field_name_regex': '(?i)^donor[-_\s]*(id)?$'
   },
   'gender': {
     'type': 'string',
@@ -78,7 +78,7 @@ material_schema = {
     'allowed': ['male', 'female', 'unknown', 'not applicable', 'mixed', 'hermaphrodite'],
     'required': True,
     'friendly_name': 'Gender',
-    'field_name_regex': '^(gender|sex)$'
+    'field_name_regex': '(?i)^(gender|sex)$'
   },
   'scientific_name': {
     'type': 'string',
@@ -87,7 +87,7 @@ material_schema = {
     'required': True,
     'allowed': ['Homo sapiens', 'Mus musculus'],
     'friendly_name': 'Scientific name',
-    'field_name_regex': '^scientific[-_\s]*(name)?$'
+    'field_name_regex': '(?i)^scientific[-_\s]*(name)?$'
   },
   'phenotype': {
     'type': 'string',
@@ -95,7 +95,7 @@ material_schema = {
     'searchable': True,
     'required': False,
     'friendly_name': 'Phenotype',
-    'field_name_regex': '^phenotype$'
+    'field_name_regex': '(?i)^phenotype$'
   },
   'hmdmc': {
     'type': 'string',

--- a/schema.py
+++ b/schema.py
@@ -39,13 +39,33 @@ material_schema = {
   },
   'supplier_name': {
     'type': 'string',
+    'show_on_form': True,
     'searchable': True,
     'required': True,
     'friendly_name': 'Supplier name',
     'field_name_regex': '^supplier[-_\s]*(name)?$'
   },
+'is_tumour': {
+  'type': 'string',
+  'show_on_form': True,
+  'searchable': True,
+  'allowed': ['tumour', 'normal'],
+  'required': True,
+  'friendly_name': 'Tumour?'
+  # needs field_name_regex
+},
+  'tissue_type': {
+    'type': 'string',
+    'show_on_form': True,
+    'searchable': True,
+    'allowed': ['DNA/RNA', 'Blood', 'Saliva', 'Tissue', 'Cells', 'Lysed Cells'],
+    'required': True,
+    'friendly_name': 'Tissue Type',
+    # needs field_name_regex
+  },
   'donor_id': {
     'type': 'string',
+    'show_on_form': True,
     'searchable': True,
     'required': True,
     'friendly_name': 'Donor ID',
@@ -53,14 +73,16 @@ material_schema = {
   },
   'gender': {
     'type': 'string',
+    'show_on_form': True,
     'searchable': True,
-    'allowed': ['male', 'female', 'unknown'],
+    'allowed': ['male', 'female', 'unknown', 'not applicable', 'mixed', 'hermaphrodite'],
     'required': True,
     'friendly_name': 'Gender',
     'field_name_regex': '^(gender|sex)$'
   },
   'scientific_name': {
     'type': 'string',
+    'show_on_form': True,
     'searchable': True,
     'required': True,
     'allowed': ['Homo sapiens', 'Mus musculus'],
@@ -69,8 +91,9 @@ material_schema = {
   },
   'phenotype': {
     'type': 'string',
+    'show_on_form': True,
     'searchable': True,
-    'required': True,
+    'required': False,
     'friendly_name': 'Phenotype',
     'field_name_regex': '^phenotype$'
   },

--- a/schema.py
+++ b/schema.py
@@ -51,8 +51,8 @@ material_schema = {
   'searchable': True,
   'allowed': ['tumour', 'normal'],
   'required': True,
-  'friendly_name': 'Tumour?'
-  # needs field_name_regex
+  'friendly_name': 'Tumour?',
+  'field_name_regex': '^(tumour|tumor)$'
 },
   'tissue_type': {
     'type': 'string',
@@ -61,7 +61,7 @@ material_schema = {
     'allowed': ['DNA/RNA', 'Blood', 'Saliva', 'Tissue', 'Cells', 'Lysed Cells'],
     'required': True,
     'friendly_name': 'Tissue Type',
-    # needs field_name_regex
+    'field_name_regex': '^tissue[-_\s]type$'
   },
   'donor_id': {
     'type': 'string',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -48,5 +48,7 @@ def valid_material_params():
     "donor_id": "my donor id 1",
     "gender": "female",
     "scientific_name": "Homo sapiens",
-    "phenotype": "eye colour"
+    "phenotype": "eye colour",
+    "tissue_type": "Blood",
+    "is_tumour": "normal"
   }

--- a/tests/materials_tests.py
+++ b/tests/materials_tests.py
@@ -101,14 +101,31 @@ class TestMaterials(ServiceTestBase):
         self.assertValidationErrorStatus(status)
         self.assertValidationError(r, {'scientific_name': 'required field'})
 
-    def test_phenotype_required_validation(self):
+    def test_tissue_type_required_validation(self):
+        data = valid_material_params()
+        del data['tissue_type']
+
+        r, status = self.post('/materials', data=data)
+
+        self.assertValidationErrorStatus(status)
+        self.assertValidationError(r, {'tissue_type': 'required field'})
+
+    def test_is_tumour_required_validation(self):
+        data = valid_material_params()
+        del data['is_tumour']
+
+        r, status = self.post('/materials', data=data)
+
+        self.assertValidationErrorStatus(status)
+        self.assertValidationError(r, {'is_tumour': 'required field'})
+
+    def test_phenotype_optional_validation(self):
         data = valid_material_params()
         del data['phenotype']
 
         r, status = self.post('/materials', data=data)
 
-        self.assertValidationErrorStatus(status)
-        self.assertValidationError(r, {'phenotype': 'required field'})
+        self.assert201(status)
 
     def test_hmdmc_invalid_format(self):
         data = valid_material_params()
@@ -282,7 +299,7 @@ class TestMaterials(ServiceTestBase):
         response, status = self.get('materials/json_schema')
         self.assert200(status)
         expected_searchable = [k for k, v in response['properties'].iteritems() if v.get('searchable')]
-        self.assertEqual(response['searchable'], expected_searchable)
+        self.assertEqual(sorted(response['searchable']), sorted(expected_searchable))
 
     def test_friendly_names(self):
         """Test that the friendly names we assign to the fields are correct"""
@@ -298,6 +315,8 @@ class TestMaterials(ServiceTestBase):
         self.assertEqual(friendly_names['donor_id'], 'Donor ID')
         self.assertEqual(friendly_names['phenotype'], 'Phenotype')
         self.assertEqual(friendly_names['supplier_name'], 'Supplier name')
+        self.assertEqual(friendly_names['is_tumour'], 'Tumour?')
+        self.assertEqual(friendly_names['tissue_type'], 'Tissue Type')
 
     def test_regex(self):
         """Test that the regular expresssions works as expected"""
@@ -326,6 +345,8 @@ class TestMaterials(ServiceTestBase):
         self.assertRegexpMatches('donor id', field_name_regexs['donor_id'])
         self.assertRegexpMatches('donor  id', field_name_regexs['donor_id'])
         self.assertRegexpMatches('donor_id', field_name_regexs['donor_id'])
+        self.assertRegexpMatches('Donor ID', field_name_regexs['donor_id'])
+        self.assertRegexpMatches('DonorID', field_name_regexs['donor_id'])
         self.assertRegexpMatches('donor-id', field_name_regexs['donor_id'])
 
         self.assertNotRegexpMatches('phenotyp', field_name_regexs['phenotype'])
@@ -336,5 +357,17 @@ class TestMaterials(ServiceTestBase):
         self.assertNotRegexpMatches('supplie', field_name_regexs['supplier_name'])
         self.assertRegexpMatches('supplier', field_name_regexs['supplier_name'])
         self.assertRegexpMatches('supplier_name', field_name_regexs['supplier_name'])
+        self.assertRegexpMatches('Supplier Name', field_name_regexs['supplier_name'])
         self.assertRegexpMatches('supplier name', field_name_regexs['supplier_name'])
         self.assertRegexpMatches('supplier-name', field_name_regexs['supplier_name'])
+
+        self.assertNotRegexpMatches('tumour shape', field_name_regexs['is_tumour'])
+        self.assertRegexpMatches('tumour', field_name_regexs['is_tumour'])
+        self.assertRegexpMatches('tumor', field_name_regexs['is_tumour'])
+
+        self.assertNotRegexpMatches('tis sue type', field_name_regexs['tissue_type'])
+        self.assertNotRegexpMatches('TISSUE', field_name_regexs['tissue_type'])
+        self.assertRegexpMatches('tissue-type', field_name_regexs['tissue_type'])
+        self.assertRegexpMatches('tissue type', field_name_regexs['tissue_type'])
+        self.assertRegexpMatches('tissue_type', field_name_regexs['tissue_type'])
+        self.assertRegexpMatches('Tissue Type', field_name_regexs['tissue_type'])


### PR DESCRIPTION
- Fields now have a separate property "show_on_form" which is used in submission, instead of "required" for displaying fields. This has allowed "Phenotype" to be set as an optional field, but still appears on the form.
- New options for "Gender" have been added
- "Tissue Type" and "Tumour" fields have been added, with their respective options