### PR TITLE
Remove case insensitive flag from schema

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -42,7 +42,7 @@ material_schema = {
     'show_on_form': True,
     'searchable': True,
     'required': True,
-    'friendly_name': 'Supplier name',
+    'friendly_name': 'Supplier Name',
     'field_name_regex': '^supplier[-_\s]*(name)?$'
   },
 'is_tumour': {
@@ -58,7 +58,7 @@ material_schema = {
     'type': 'string',
     'show_on_form': True,
     'searchable': True,
-    'allowed': ['DNA/RNA', 'Blood', 'Saliva', 'Tissue', 'Cells', 'Lysed Cells'],
+    'allowed': ['dna/rna', 'blood', 'saliva', 'tissue', 'cells', 'lysed cells'],
     'required': True,
     'friendly_name': 'Tissue Type',
     'field_name_regex': '^tissue[-_\s]type$'
@@ -85,8 +85,8 @@ material_schema = {
     'show_on_form': True,
     'searchable': True,
     'required': True,
-    'allowed': ['Homo sapiens', 'Mus musculus'],
-    'friendly_name': 'Scientific name',
+    'allowed': ['homo sapiens', 'mus musculus'],
+    'friendly_name': 'Scientific Name',
     'field_name_regex': '^scientific[-_\s]*(name)?$'
   },
   'phenotype': {

--- a/schema.py
+++ b/schema.py
@@ -43,7 +43,7 @@ material_schema = {
     'searchable': True,
     'required': True,
     'friendly_name': 'Supplier name',
-    'field_name_regex': '(?i)^supplier[-_\s]*(name)?$'
+    'field_name_regex': '^supplier[-_\s]*(name)?$'
   },
 'is_tumour': {
   'type': 'string',
@@ -52,7 +52,7 @@ material_schema = {
   'allowed': ['tumour', 'normal'],
   'required': True,
   'friendly_name': 'Tumour?',
-  'field_name_regex': '(?i)^(tumour|tumor)$'
+  'field_name_regex': '^(tumour|tumor)$'
 },
   'tissue_type': {
     'type': 'string',
@@ -61,7 +61,7 @@ material_schema = {
     'allowed': ['DNA/RNA', 'Blood', 'Saliva', 'Tissue', 'Cells', 'Lysed Cells'],
     'required': True,
     'friendly_name': 'Tissue Type',
-    'field_name_regex': '(?i)^tissue[-_\s]type$'
+    'field_name_regex': '^tissue[-_\s]type$'
   },
   'donor_id': {
     'type': 'string',
@@ -69,7 +69,7 @@ material_schema = {
     'searchable': True,
     'required': True,
     'friendly_name': 'Donor ID',
-    'field_name_regex': '(?i)^donor[-_\s]*(id)?$'
+    'field_name_regex': '^donor[-_\s]*(id)?$'
   },
   'gender': {
     'type': 'string',
@@ -78,7 +78,7 @@ material_schema = {
     'allowed': ['male', 'female', 'unknown', 'not applicable', 'mixed', 'hermaphrodite'],
     'required': True,
     'friendly_name': 'Gender',
-    'field_name_regex': '(?i)^(gender|sex)$'
+    'field_name_regex': '^(gender|sex)$'
   },
   'scientific_name': {
     'type': 'string',
@@ -87,7 +87,7 @@ material_schema = {
     'required': True,
     'allowed': ['Homo sapiens', 'Mus musculus'],
     'friendly_name': 'Scientific name',
-    'field_name_regex': '(?i)^scientific[-_\s]*(name)?$'
+    'field_name_regex': '^scientific[-_\s]*(name)?$'
   },
   'phenotype': {
     'type': 'string',
@@ -95,7 +95,7 @@ material_schema = {
     'searchable': True,
     'required': False,
     'friendly_name': 'Phenotype',
-    'field_name_regex': '(?i)^phenotype$'
+    'field_name_regex': '^phenotype$'
   },
   'hmdmc': {
     'type': 'string',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -47,8 +47,8 @@ def valid_material_params():
     "supplier_name": "my supplier name 1",
     "donor_id": "my donor id 1",
     "gender": "female",
-    "scientific_name": "Homo sapiens",
+    "scientific_name": "homo sapiens",
     "phenotype": "eye colour",
-    "tissue_type": "Blood",
+    "tissue_type": "blood",
     "is_tumour": "normal"
   }

--- a/tests/materials_tests.py
+++ b/tests/materials_tests.py
@@ -345,8 +345,6 @@ class TestMaterials(ServiceTestBase):
         self.assertRegexpMatches('donor id', field_name_regexs['donor_id'])
         self.assertRegexpMatches('donor  id', field_name_regexs['donor_id'])
         self.assertRegexpMatches('donor_id', field_name_regexs['donor_id'])
-        self.assertRegexpMatches('Donor ID', field_name_regexs['donor_id'])
-        self.assertRegexpMatches('DonorID', field_name_regexs['donor_id'])
         self.assertRegexpMatches('donor-id', field_name_regexs['donor_id'])
 
         self.assertNotRegexpMatches('phenotyp', field_name_regexs['phenotype'])
@@ -357,7 +355,6 @@ class TestMaterials(ServiceTestBase):
         self.assertNotRegexpMatches('supplie', field_name_regexs['supplier_name'])
         self.assertRegexpMatches('supplier', field_name_regexs['supplier_name'])
         self.assertRegexpMatches('supplier_name', field_name_regexs['supplier_name'])
-        self.assertRegexpMatches('Supplier Name', field_name_regexs['supplier_name'])
         self.assertRegexpMatches('supplier name', field_name_regexs['supplier_name'])
         self.assertRegexpMatches('supplier-name', field_name_regexs['supplier_name'])
 
@@ -370,4 +367,3 @@ class TestMaterials(ServiceTestBase):
         self.assertRegexpMatches('tissue-type', field_name_regexs['tissue_type'])
         self.assertRegexpMatches('tissue type', field_name_regexs['tissue_type'])
         self.assertRegexpMatches('tissue_type', field_name_regexs['tissue_type'])
-        self.assertRegexpMatches('Tissue Type', field_name_regexs['tissue_type'])

--- a/tests/materials_tests.py
+++ b/tests/materials_tests.py
@@ -310,11 +310,11 @@ class TestMaterials(ServiceTestBase):
             k: v.get('friendly_name')
             for k, v in response['properties'].iteritems() if v.get('friendly_name')}
 
-        self.assertEqual(friendly_names['scientific_name'], 'Scientific name')
+        self.assertEqual(friendly_names['scientific_name'], 'Scientific Name')
         self.assertEqual(friendly_names['gender'], 'Gender')
         self.assertEqual(friendly_names['donor_id'], 'Donor ID')
         self.assertEqual(friendly_names['phenotype'], 'Phenotype')
-        self.assertEqual(friendly_names['supplier_name'], 'Supplier name')
+        self.assertEqual(friendly_names['supplier_name'], 'Supplier Name')
         self.assertEqual(friendly_names['is_tumour'], 'Tumour?')
         self.assertEqual(friendly_names['tissue_type'], 'Tissue Type')
 


### PR DESCRIPTION
Adding the CI flag here breaks the CSV mapper in submission, as the case insensitivity flag is also added there. While it'd make more sense to store them together, it seems these modifiers aren't generally part of the main expression, but specified when they are used. This behaviour could be added to the material schema, but would then make the regexs language specific.

This means we can't test case insensitivity using python tests, as case-insensitive strings will only pass in the submission CSV mapper